### PR TITLE
chore(deps): move the server image to itzg/minecraft-server 2026.9.0

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,8 +6,8 @@
 # images lives in the compose file's `x-images` block, so `git pull`
 # delivers the version combination this repository has tested. To pin a
 # different version yourself, uncomment and set:
-# MINECRAFT_SERVER_IMAGE_TAG=itzg/minecraft-server:2026.8.2@sha256:…
-# MINECRAFT_SERVER_BACKUP_IMAGE_TAG=itzg/mc-backup:2026.8.2@sha256:…
+# MINECRAFT_SERVER_IMAGE_TAG=itzg/minecraft-server:2026.9.0@sha256:…
+# MINECRAFT_SERVER_BACKUP_IMAGE_TAG=itzg/mc-backup:2026.9.0@sha256:…
 
 # ──────────────────────────────────────────────────────────────────────────────
 # Required
@@ -75,5 +75,5 @@ MINECRAFT_SERVER_RCON_PASSWORD=change_me_before_first_start
 # of that one image (Compose then pulls the tag, without a digest) while every
 # other pin stays as tested. Setting <PREFIX>_IMAGE_TAG replaces the whole
 # reference instead. Needs Docker Compose v2.5 or newer (2022).
-# MINECRAFT_SERVER_IMAGE_VERSION=2026.8.2
-# MINECRAFT_SERVER_BACKUP_IMAGE_VERSION=2026.8.2
+# MINECRAFT_SERVER_IMAGE_VERSION=2026.9.0
+# MINECRAFT_SERVER_BACKUP_IMAGE_VERSION=2026.9.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _(no unreleased changes yet)_
 
+## [1.5.1] - 2026-09-06
+
+### Changed
+
+- **The server image moves to `itzg/minecraft-server:2026.9.0`.** The release
+  is bug fixes and hardening: a modpack archive that cannot be extracted, a
+  `CUSTOM_SERVER` download that returns an HTTP error, and a failed FTB
+  installer now stop startup instead of leaving a half-installed server
+  running. Percentage memory sizes are computed with integer arithmetic. The
+  compose file boots and the backup cycle is exercised against the new image
+  before this lands.
+
+### Fixed
+
+- **`.env.example` named image versions the compose file no longer pins.** It
+  still showed `2026.8.2` for the backup image while the compose default was
+  `2026.9.0`, so anyone copying the commented line as a starting point pinned
+  something older than the tested combination.
+
 ## [1.5.0] - 2026-09-05
 
 ### Added
@@ -146,7 +165,8 @@ v1.2.0.
   ephemeral credentials, waits for the built-in healthcheck, proves RCON
   answers `list`, and requires a backup archive to appear.
 
-[Unreleased]: https://github.com/heyvaldemar/minecraft-server-docker-compose/compare/v1.5.0...HEAD
+[Unreleased]: https://github.com/heyvaldemar/minecraft-server-docker-compose/compare/v1.5.1...HEAD
+[1.5.1]: https://github.com/heyvaldemar/minecraft-server-docker-compose/compare/v1.5.0...v1.5.1
 [1.5.0]: https://github.com/heyvaldemar/minecraft-server-docker-compose/compare/v1.4.0...v1.5.0
 [1.4.0]: https://github.com/heyvaldemar/minecraft-server-docker-compose/compare/v1.3.0...v1.4.0
 [1.3.0]: https://github.com/heyvaldemar/minecraft-server-docker-compose/compare/v1.2.0...v1.3.0

--- a/minecraft-server-docker-compose.yml
+++ b/minecraft-server-docker-compose.yml
@@ -6,7 +6,7 @@
 # CI (Trivy scans, check-pin-freshness, the ephemeral test .env) reads
 # the pins from these lines — this block is the single source of truth.
 x-images:
-  minecraft: &minecraft-image ${MINECRAFT_SERVER_IMAGE_TAG:-itzg/minecraft-server:${MINECRAFT_SERVER_IMAGE_VERSION:-2026.8.2@sha256:efa878ddb49cf5251b2e5f2ad71b08fd2f7236c1f7907433f6697258b31d2ce4}}
+  minecraft: &minecraft-image ${MINECRAFT_SERVER_IMAGE_TAG:-itzg/minecraft-server:${MINECRAFT_SERVER_IMAGE_VERSION:-2026.9.0@sha256:4e29d14082d94748f945edad3ee5307b97adc730fec49860199f5e52218a9ae3}}
   mc-backup: &mc-backup-image ${MINECRAFT_SERVER_BACKUP_IMAGE_TAG:-itzg/mc-backup:${MINECRAFT_SERVER_BACKUP_IMAGE_VERSION:-2026.9.0@sha256:89ee1d9d1ee47891123147ac191d0522acc4cde727422681f6b8abf044a3badd}}
 
 networks:


### PR DESCRIPTION
The nightly freshness check reported the server pin behind: `2026.8.2` against `2026.9.0`, published 5 September. The jump crosses a minor boundary, so fleet triage reports it and refuses to bump it on its own — that call is made here.

Upstream shipped bug fixes and hardening, no behaviour change for a vanilla server. The ones that matter for a stack that restarts unattended: a modpack zip that cannot be extracted, a `CUSTOM_SERVER` download returning an HTTP error, and a failed FTB App installer now stop startup instead of leaving a half-installed server that looks like it came up. Percentage memory sizes are computed with integer arithmetic. Full notes: [2026.8.2…2026.9.0](https://github.com/itzg/docker-minecraft-server/compare/2026.8.2...2026.9.0).

The digest is resolved and pinned, not left floating: `2026.9.0@sha256:4e29d140…`.

The same commit fixes documentation that had drifted. `.env.example` still offered `2026.8.2` for both images — including the backup image, whose compose default has been `2026.9.0` for a day. Copying the commented line as a starting point pinned something older than the combination this repository tests.

Verification is the repository's own gate: `docker compose up`, the server reaching a listening state, and the backup cycle exercised end to end against the new image before this is mergeable.
